### PR TITLE
DIGG-574 Removed Shib maven repo from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,6 @@
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>
     </repository>
-    <repository>
-      <id>shibboleth</id>
-      <name>Shibboleth Maven Repo</name>
-      <url>https://build.shibboleth.net/nexus/content/repositories/releases</url>
-    </repository>
   </repositories>
 
   <distributionManagement>


### PR DESCRIPTION
There is no need to refer to the Shibboleth Maven repo in the central parent POM. It only contains OpenSAML artefacts, and we only need these for SAML-implementations.
