### PR TITLE
DIGG-571 State and session handling

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -18,7 +18,8 @@ signservice:
     key-password: secret
   engines:
   - name: "Sandbox"
-    processing-path: /sign/sandbox
+    processing-paths:
+    - /sign/sandbox          
     sign-service-id: https://signservice.digg.se
     client:
       client-id: https://eid2cssp.3xasecurity.com/sign

--- a/core/src/main/java/se/swedenconnect/signservice/session/SignServiceSession.java
+++ b/core/src/main/java/se/swedenconnect/signservice/session/SignServiceSession.java
@@ -94,7 +94,7 @@ public interface SignServiceSession {
    * Adds the {@link SignServiceContext} to the session.
    * <p>
    * This method is a convenience method that corresponds to the call
-   * {@code setSessionAttribute(SignServiceSession.CONTEXT_SESSION_NAME, context)}.
+   * {@code setAttribute(SignServiceSession.CONTEXT_SESSION_NAME, context)}.
    * </p>
    *
    * @param context the context to add

--- a/core/src/main/java/se/swedenconnect/signservice/session/impl/DefaultSignServiceSession.java
+++ b/core/src/main/java/se/swedenconnect/signservice/session/impl/DefaultSignServiceSession.java
@@ -16,88 +16,100 @@
 
 package se.swedenconnect.signservice.session.impl;
 
-import se.swedenconnect.signservice.session.SignServiceContext;
-import se.swedenconnect.signservice.session.SignServiceSession;
-
-import javax.servlet.http.HttpSession;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import javax.servlet.http.HttpSession;
+
+import se.swedenconnect.signservice.session.SignServiceContext;
+import se.swedenconnect.signservice.session.SignServiceSession;
+
 /**
- * {@link SignServiceSession} implementation where sessions are backed by
- * underlying {@link HttpSession} objects.
+ * {@link SignServiceSession} implementation where sessions are backed by underlying {@link HttpSession} objects.
  */
 class DefaultSignServiceSession implements SignServiceSession {
 
-    private final HttpSession inner;
+  private final HttpSession inner;
 
-    /**
-     * Private constructor.
-     *
-     * @param httpSession The underlying session object. Must not be null.
-     * @throws NullPointerException in case {@code httpSession} is null.
-     */
-    DefaultSignServiceSession(HttpSession httpSession) {
-        Objects.requireNonNull("httpSession cannot be null.");
-        this.inner = httpSession;
-    }
+  /**
+   * Private constructor.
+   *
+   * @param httpSession The underlying session object. Must not be null
+   * @throws NullPointerException in case httpSession is null
+   */
+  DefaultSignServiceSession(final HttpSession httpSession) {
+    this.inner = Objects.requireNonNull(httpSession, "httpSession cannot be null");
+  }
 
-    @Override
-    public String getId() {
-        return this.inner.getId();
-    }
+  /** {@inheritDoc} */
+  @Override
+  public String getId() {
+    return this.inner.getId();
+  }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T extends Serializable> T getAttribute(final String name) throws IllegalStateException, ClassCastException {
-        return (T) this.inner.getAttribute(name);
-    }
+  /** {@inheritDoc} */
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T extends Serializable> T getAttribute(final String name) throws IllegalStateException, ClassCastException {
+    return (T) this.inner.getAttribute(name);
+  }
 
-    @Override
-    public <T extends Serializable> T getAttribute(final String name, final Class<T> type) throws IllegalStateException, ClassCastException {
-        return type.cast(this.inner.getAttribute(name));
-    }
+  /** {@inheritDoc} */
+  @Override
+  public <T extends Serializable> T getAttribute(final String name, final Class<T> type)
+      throws IllegalStateException, ClassCastException {
+    return type.cast(this.inner.getAttribute(name));
+  }
 
-    @Override
-    public SignServiceContext getSignServiceContext() throws IllegalStateException {
-        return (SignServiceContext) this.inner.getAttribute(CONTEXT_NAME);
-    }
+  /** {@inheritDoc} */
+  @Override
+  public SignServiceContext getSignServiceContext() throws IllegalStateException {
+    return (SignServiceContext) this.inner.getAttribute(CONTEXT_NAME);
+  }
 
-    @Override
-    public void setSignServiceContext(final SignServiceContext context) throws IllegalStateException {
-        this.inner.setAttribute(CONTEXT_NAME, context);
-    }
+  /** {@inheritDoc} */
+  @Override
+  public void setSignServiceContext(final SignServiceContext context) throws IllegalStateException {
+    this.inner.setAttribute(CONTEXT_NAME, context);
+  }
 
-    @Override
-    public List<String> getAttributeNames() throws IllegalStateException {
-        return Collections.list(this.inner.getAttributeNames());
-    }
+  /** {@inheritDoc} */
+  @Override
+  public List<String> getAttributeNames() throws IllegalStateException {
+    return Collections.list(this.inner.getAttributeNames());
+  }
 
-    @Override
-    public <T extends Serializable> void setAttribute(final String name, final T attribute) throws IllegalStateException {
-        this.inner.setAttribute(name, attribute);
-    }
+  /** {@inheritDoc} */
+  @Override
+  public <T extends Serializable> void setAttribute(final String name, final T attribute) throws IllegalStateException {
+    this.inner.setAttribute(name, attribute);
+  }
 
-    @Override
-    public void removeAttribute(final String name) throws IllegalStateException {
-        this.inner.removeAttribute(name);
-    }
+  /** {@inheritDoc} */
+  @Override
+  public void removeAttribute(final String name) throws IllegalStateException {
+    this.inner.removeAttribute(name);
+  }
 
-    @Override
-    public void invalidate() {
-        this.inner.invalidate();
-    }
+  /** {@inheritDoc} */
+  @Override
+  public void invalidate() {
+    this.inner.invalidate();
+  }
 
-    @Override
-    public Instant getCreationTime() throws IllegalStateException {
-        return Instant.ofEpochMilli(this.inner.getCreationTime());
-    }
+  /** {@inheritDoc} */
+  @Override
+  public Instant getCreationTime() throws IllegalStateException {
+    return Instant.ofEpochMilli(this.inner.getCreationTime());
+  }
 
-    @Override
-    public Instant getLastAccessedTime() throws IllegalStateException {
-        return Instant.ofEpochMilli(this.inner.getLastAccessedTime());
-    }
+  /** {@inheritDoc} */
+  @Override
+  public Instant getLastAccessedTime() throws IllegalStateException {
+    return Instant.ofEpochMilli(this.inner.getLastAccessedTime());
+  }
+
 }

--- a/engine/src/main/java/se/swedenconnect/signservice/api/engine/config/EngineConfiguration.java
+++ b/engine/src/main/java/se/swedenconnect/signservice/api/engine/config/EngineConfiguration.java
@@ -52,11 +52,11 @@ public interface EngineConfiguration {
   PkiCredential getSignServiceCredential();
 
   /**
-   * Gets the path (relative the application root) for the SignRequest processing endpoint.
+   * Gets the path, or paths, relative the application root/context path for the SignRequest processing endpoint(s).
    *
-   * @return the processing path
+   * @return the processing path(s)
    */
-  String getProcessingPath();
+  List<String> getProcessingPaths();
 
   /**
    * Gets the protocol handler to use when decoding and encoding messages.

--- a/engine/src/main/java/se/swedenconnect/signservice/api/engine/config/impl/DefaultEngineConfiguration.java
+++ b/engine/src/main/java/se/swedenconnect/signservice/api/engine/config/impl/DefaultEngineConfiguration.java
@@ -16,6 +16,7 @@
 package se.swedenconnect.signservice.api.engine.config.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -62,12 +63,12 @@ public class DefaultEngineConfiguration implements EngineConfiguration {
   private PkiCredential signServiceCredential;
 
   /**
-   * The processing path (relative to the application's context path).
+   * The processing paths (relative to the application's context path).
    *
-   * @param processingPath the processing path
+   * @param processingPaths the processing paths
    */
   @Setter
-  private String processingPath;
+  private List<String> processingPaths;
 
   /**
    * The protocol handler this engine uses.
@@ -131,8 +132,8 @@ public class DefaultEngineConfiguration implements EngineConfiguration {
     if (this.signServiceCredential == null) {
       throw new IllegalArgumentException("signServiceCredential must be set");
     }
-    if (StringUtils.isBlank(this.processingPath)) {
-      throw new IllegalArgumentException("processingPath must be set");
+    if (this.processingPaths == null || this.processingPaths.isEmpty()) {
+      throw new IllegalArgumentException("processingPaths must be set");
     }
     if (this.protocolHandler == null) {
       throw new IllegalArgumentException("protocolHandler must be set");
@@ -171,8 +172,8 @@ public class DefaultEngineConfiguration implements EngineConfiguration {
 
   /** {@inheritDoc} */
   @Override
-  public String getProcessingPath() {
-    return this.processingPath;
+  public List<String> getProcessingPaths() {
+    return this.processingPaths != null ? Collections.unmodifiableList(this.processingPaths) : null;
   }
 
   /** {@inheritDoc} */

--- a/engine/src/main/java/se/swedenconnect/signservice/api/engine/session/SignOperationState.java
+++ b/engine/src/main/java/se/swedenconnect/signservice/api/engine/session/SignOperationState.java
@@ -26,7 +26,7 @@ public enum SignOperationState {
   /** State that tells that user authentication is ongoing. */
   AUTHN_ONGOING,
 
-  // TODO: more here
+  /** State that tells that the engine is in the process of performing the signing operation. */
+  SIGNING;
 
-  COMPLETED;
 }

--- a/spring-boot-starter/src/main/java/se/swedenconnect/signservice/spring/config/SignServiceConfiguration.java
+++ b/spring-boot-starter/src/main/java/se/swedenconnect/signservice/spring/config/SignServiceConfiguration.java
@@ -177,7 +177,7 @@ public class SignServiceConfiguration {
         conf.setSignServiceCredential(defaultCredential);
       }
 
-      conf.setProcessingPath(ecp.getProcessingPath());
+      conf.setProcessingPaths(ecp.getProcessingPaths());
 
       conf.setProtocolHandler(this.protocolHandler()); // TODO: change
       conf.setAuthenticationHandler(new MockAuthnHandler());  // TODO: change

--- a/spring-boot-starter/src/main/java/se/swedenconnect/signservice/spring/config/engine/EngineConfigurationProperties.java
+++ b/spring-boot-starter/src/main/java/se/swedenconnect/signservice/spring/config/engine/EngineConfigurationProperties.java
@@ -15,6 +15,8 @@
  */
 package se.swedenconnect.signservice.spring.config.engine;
 
+import java.util.List;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
@@ -43,9 +45,9 @@ public class EngineConfigurationProperties implements InitializingBean {
   private PkiCredentialConfigurationProperties credential;
 
   /**
-   * The engine processing path.
+   * The engine processing path(s).
    */
-  private String processingPath;
+  private List<String> processingPaths;
 
   /**
    * The client configuration.
@@ -64,7 +66,7 @@ public class EngineConfigurationProperties implements InitializingBean {
   public void afterPropertiesSet() throws Exception {
     Assert.hasText(this.name, "name must be assigned");
     Assert.hasText(this.signServiceId, "sign-service-id must be assigned");
-    Assert.hasText(this.processingPath, "processing-path must be assigned");
+    Assert.notEmpty(this.processingPaths, "processing-paths must be assigned and non-empty");
 
     Assert.notNull(client, "client must be assigned");
     this.client.afterPropertiesSet();


### PR DESCRIPTION
Added functionality that handles the case when a new SignRequest is received when the current session state states that the engine is waiting for the user to be authenticated. This fix is necessary so that we don't end up with dangling sessions that can occur if the user abandons the authentication and instead initiates a new signature operation.
