### PR TITLE
IS-53 URL comparison fixes

### DIFF
--- a/authn/saml/src/main/java/se/swedenconnect/signservice/authn/saml/AbstractSamlAuthenticationHandler.java
+++ b/authn/saml/src/main/java/se/swedenconnect/signservice/authn/saml/AbstractSamlAuthenticationHandler.java
@@ -375,7 +375,7 @@ public abstract class AbstractSamlAuthenticationHandler extends AbstractSignServ
       return false;
     }
 
-    final String requestPath = httpRequest.getRequestURI();
+    final String requestPath = httpRequest.getServletPath();
     if (!(requestPath.equalsIgnoreCase(this.urlConfiguration.getAssertionConsumerPath())
         || (this.urlConfiguration.getAdditionalAssertionConsumerPath() != null
             && requestPath.equalsIgnoreCase(this.urlConfiguration.getAdditionalAssertionConsumerPath())))) {
@@ -445,7 +445,7 @@ public abstract class AbstractSamlAuthenticationHandler extends AbstractSignServ
     if (!"GET".equals(httpRequest.getMethod())) {
       return false;
     }
-    return httpRequest.getRequestURI().equalsIgnoreCase(this.urlConfiguration.getMetadataPublishingPath());
+    return httpRequest.getServletPath().equalsIgnoreCase(this.urlConfiguration.getMetadataPublishingPath());
   }
 
   /**
@@ -554,7 +554,7 @@ public abstract class AbstractSamlAuthenticationHandler extends AbstractSignServ
 
       @Override
       public String getReceiveURL() {
-        return baseUrl + httpRequest.getRequestURI();
+        return baseUrl + httpRequest.getServletPath();
       }
 
       @Override

--- a/authn/saml/src/main/java/se/swedenconnect/signservice/authn/saml/config/SpUrlConfiguration.java
+++ b/authn/saml/src/main/java/se/swedenconnect/signservice/authn/saml/config/SpUrlConfiguration.java
@@ -28,7 +28,7 @@ import lombok.Getter;
 public class SpUrlConfiguration {
 
   /**
-   * The application base URL. Must not end with a slash.
+   * The application base URL. Must not end with a slash. The base URL consists of the protocol, host and context path.
    */
   @Getter
   private String baseUrl;

--- a/authn/saml/src/test/java/se/swedenconnect/signservice/authn/saml/DefaultSamlAuthenticationHandlerTest.java
+++ b/authn/saml/src/test/java/se/swedenconnect/signservice/authn/saml/DefaultSamlAuthenticationHandlerTest.java
@@ -223,7 +223,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testCanProcess() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("response");
 
@@ -237,7 +237,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testCanProcessMatchAdditional() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("response");
 
@@ -249,7 +249,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testCanProcessMismatchingPath() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn("/saml/other");
+    Mockito.when(request.getServletPath()).thenReturn("/saml/other");
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("response");
 
@@ -277,7 +277,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testCanProcessMissingAuthnRequest() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("response");
 
@@ -290,7 +290,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthentication() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -366,7 +366,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationCantProcess() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn(null);
 
@@ -378,7 +378,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationNoAuthnRequest() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -400,7 +400,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationUserCancel() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -447,7 +447,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationNoIdP() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -489,7 +489,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationNoAuthnContext() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -537,7 +537,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationFailedAuthn() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -587,7 +587,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testResumeAuthenticationProcessingError() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -623,7 +623,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testSupports() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("GET");
 
     Assertions.assertTrue(handler.supports(request));
@@ -632,7 +632,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testSupportsBadMethod() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
 
     Assertions.assertFalse(handler.supports(request));
@@ -641,7 +641,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testSupportsBadPath() {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn("/other");
+    Mockito.when(request.getServletPath()).thenReturn("/other");
     Mockito.when(request.getMethod()).thenReturn("GET");
 
     Assertions.assertFalse(handler.supports(request));
@@ -650,7 +650,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testGetResource() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("GET");
     Mockito.when(request.getHeader(eq("Accept"))).thenReturn(null);
 
@@ -671,7 +671,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testGetResourceNotUpdated() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("GET");
     Mockito.when(request.getHeader(eq("Accept")))
         .thenReturn(AbstractSamlAuthenticationHandler.APPLICATION_SAML_METADATA);
@@ -694,7 +694,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testGetResourceFailed() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("GET");
     Mockito.when(request.getHeader(eq("Accept"))).thenReturn(null);
 
@@ -714,7 +714,7 @@ public class DefaultSamlAuthenticationHandlerTest extends OpenSamlTestBase {
   @Test
   public void testGetResourceSupportsFails() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(METADATA_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(METADATA_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 

--- a/authn/saml/src/test/java/se/swedenconnect/signservice/authn/saml/SwedenConnectSamlAuthenticationHandlerTest.java
+++ b/authn/saml/src/test/java/se/swedenconnect/signservice/authn/saml/SwedenConnectSamlAuthenticationHandlerTest.java
@@ -172,7 +172,7 @@ public class SwedenConnectSamlAuthenticationHandlerTest extends DefaultSamlAuthe
         (SwedenConnectSamlAuthenticationHandler) this.createHandler();
 
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -263,7 +263,7 @@ public class SwedenConnectSamlAuthenticationHandlerTest extends DefaultSamlAuthe
         (SwedenConnectSamlAuthenticationHandler) this.createHandler();
 
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);
@@ -330,7 +330,7 @@ public class SwedenConnectSamlAuthenticationHandlerTest extends DefaultSamlAuthe
         (SwedenConnectSamlAuthenticationHandler) this.createHandler();
 
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRequestURI()).thenReturn(ASSERTION_CONSUMER_PATH);
+    Mockito.when(request.getServletPath()).thenReturn(ASSERTION_CONSUMER_PATH);
     Mockito.when(request.getMethod()).thenReturn("POST");
     Mockito.when(request.getParameter(eq("SAMLResponse"))).thenReturn("SAML-RESPONSE");
     Mockito.when(request.getParameter(eq("RelayState"))).thenReturn(CONTEXT_ID);

--- a/engine/src/main/java/se/swedenconnect/signservice/engine/DefaultSignServiceEngine.java
+++ b/engine/src/main/java/se/swedenconnect/signservice/engine/DefaultSignServiceEngine.java
@@ -746,7 +746,7 @@ public class DefaultSignServiceEngine implements SignServiceEngine {
    * @return true if the request is sent to a SignRequest endpoint and false otherwise
    */
   protected boolean isSignRequestEndpoint(final HttpServletRequest httpRequest) {
-    final String request = httpRequest.getRequestURI();
+    final String request = httpRequest.getServletPath();
     return this.engineConfiguration.getProcessingPaths().stream()
         .anyMatch(p -> p.equalsIgnoreCase(request));
   }

--- a/engine/src/main/java/se/swedenconnect/signservice/engine/config/EngineConfiguration.java
+++ b/engine/src/main/java/se/swedenconnect/signservice/engine/config/EngineConfiguration.java
@@ -55,7 +55,7 @@ public interface EngineConfiguration {
   /**
    * Gets the path, or paths, for the SignRequest processing endpoint(s).
    * <p>
-   * Note: The paths should be relative to the application base URL, i.e., they should include the context path.
+   * Note: The paths should be relative to the application base URL, i.e., they should not include the context path.
    * </p>
    *
    * @return the processing path(s)

--- a/engine/src/test/java/se/swedenconnect/signservice/engine/DefaultSignServiceEngineTest.java
+++ b/engine/src/test/java/se/swedenconnect/signservice/engine/DefaultSignServiceEngineTest.java
@@ -128,13 +128,13 @@ public class DefaultSignServiceEngineTest {
     doNothing().when(provider1).getResource(any(), any());
     when(provider1.supports(any())).thenAnswer(a -> {
       final HttpServletRequest req = a.getArgument(0, HttpServletRequest.class);
-      return RESOURCE_PATH.equals(req.getRequestURI());
+      return RESOURCE_PATH.equals(req.getServletPath());
     });
     final HttpResourceProvider provider2 = mock(HttpResourceProvider.class);
     doThrow(IOException.class).when(provider2).getResource(any(), any());
     when(provider2.supports(any())).thenAnswer(a -> {
       final HttpServletRequest req = a.getArgument(0, HttpServletRequest.class);
-      return ERROR_RESOURCE_PATH.equals(req.getRequestURI());
+      return ERROR_RESOURCE_PATH.equals(req.getServletPath());
     });
     when(this.engineConfiguration.getHttpResourceProviders()).thenReturn(List.of(provider1, provider2));
 
@@ -150,7 +150,7 @@ public class DefaultSignServiceEngineTest {
 
     when(this.authnHandler.canProcess(any(), any())).thenAnswer(a -> {
       final HttpServletRequest req = a.getArgument(0, HttpServletRequest.class);
-      return SAML_POST_PATH.equals(req.getRequestURI()) || METADATA_PATH.equals(req.getRequestURI());
+      return SAML_POST_PATH.equals(req.getServletPath()) || METADATA_PATH.equals(req.getServletPath());
     });
 
     final HttpRequestMessage authnRequest = mock(HttpRequestMessage.class);
@@ -262,7 +262,7 @@ public class DefaultSignServiceEngineTest {
     this.systemAuditLogger = new TestAuditLogger();
 
     this.httpRequest = mock(HttpServletRequest.class);
-    when(this.httpRequest.getRequestURI()).thenReturn(SIGNREQUEST_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(SIGNREQUEST_PATH);
     when(this.httpRequest.getRemoteAddr()).thenReturn("187.11.12.45");
 
     this.httpResponse = mock(HttpServletResponse.class);
@@ -355,7 +355,7 @@ public class DefaultSignServiceEngineTest {
 
     // OK, now the user has been to the IdP and is posted back ...
 
-    when(this.httpRequest.getRequestURI()).thenReturn(SAML_POST_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(SAML_POST_PATH);
 
     result = engine.processRequest(this.httpRequest, this.httpResponse);
     Assertions.assertNotNull(result);
@@ -386,7 +386,7 @@ public class DefaultSignServiceEngineTest {
 
     // OK, now the user has been to the IdP and is posted back ...
 
-    when(this.httpRequest.getRequestURI()).thenReturn(SAML_POST_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(SAML_POST_PATH);
 
     result = engine.processRequest(this.httpRequest, this.httpResponse);
     Assertions.assertNotNull(result);
@@ -483,7 +483,7 @@ public class DefaultSignServiceEngineTest {
 
     engine.processRequest(this.httpRequest, this.httpResponse);
 
-    when(this.httpRequest.getRequestURI()).thenReturn(SAML_POST_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(SAML_POST_PATH);
     when(this.authnHandler.resumeAuthentication(any(), any())).thenThrow(
         new UserAuthenticationException(AuthenticationErrorCode.USER_CANCEL, "msg"));
 
@@ -549,7 +549,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn(METADATA_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(METADATA_PATH);
 
     Assertions.assertTrue(engine.canProcess(this.httpRequest));
   }
@@ -560,7 +560,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn("/other");
+    when(this.httpRequest.getServletPath()).thenReturn("/other");
 
     Assertions.assertFalse(engine.canProcess(this.httpRequest));
   }
@@ -571,7 +571,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn("/other");
+    when(this.httpRequest.getServletPath()).thenReturn("/other");
 
     final HttpResourceProvider p = mock(HttpResourceProvider.class);
     when(p.supports(any())).thenReturn(true);
@@ -586,7 +586,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn(RESOURCE_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(RESOURCE_PATH);
     Assertions.assertNull(engine.processRequest(this.httpRequest, this.httpResponse));
   }
 
@@ -596,7 +596,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn(ERROR_RESOURCE_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(ERROR_RESOURCE_PATH);
 
     assertThatThrownBy(() -> {
       engine.processRequest(this.httpRequest, this.httpResponse);
@@ -612,7 +612,7 @@ public class DefaultSignServiceEngineTest {
         this.engineConfiguration, this.sessionHandler, this.messageReplayChecker, this.systemAuditLogger);
     engine.setSignRequestMessageVerifier(this.signRequestMessageVerifier);
 
-    when(this.httpRequest.getRequestURI()).thenReturn(SAML_POST_PATH);
+    when(this.httpRequest.getServletPath()).thenReturn(SAML_POST_PATH);
 
     assertThatThrownBy(() -> {
       engine.processRequest(this.httpRequest, this.httpResponse);

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandler.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandler.java
@@ -180,7 +180,7 @@ public class SimpleKeyAndCertificateHandler extends AbstractCaEngineKeyAndCertif
     if (!"GET".equals(httpRequest.getMethod())) {
       return false;
     }
-    return this.crlPublishPath.equalsIgnoreCase(httpRequest.getRequestURI());
+    return this.crlPublishPath.equalsIgnoreCase(httpRequest.getServletPath());
   }
 
 }

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
@@ -34,7 +34,7 @@ import se.swedenconnect.signservice.certificate.simple.SimpleKeyAndCertificateHa
 public class SimpleKeyAndCertificateHandlerConfiguration extends AbstractKeyAndCertificateHandlerConfiguration {
 
   /**
-   * The application base URL. Must not end with a slash.
+   * The application base URL. Must not end with a slash. The base URL consists of the protocol, host and context path.
    */
   @Getter
   private String baseUrl;

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactory.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactory.java
@@ -89,8 +89,7 @@ public class SimpleKeyAndCertificateHandlerFactory extends AbstractKeyAndCertifi
         .filter(c -> StringUtils.isNotBlank(c))
         .orElseThrow(() -> new IllegalArgumentException("CRL distributions point path must be set"));
 
-    final String crlDp = String.format("%s%s",
-        Optional.ofNullable(conf.getBaseUrl())
+    final String crlDp = String.format("%s%s", Optional.ofNullable(conf.getBaseUrl())
         .filter(c -> StringUtils.isNotBlank(c))
         .orElseThrow(() -> new IllegalArgumentException("Base URL must be set")), crlDpPath);
 

--- a/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandlerTest.java
+++ b/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandlerTest.java
@@ -258,7 +258,7 @@ class SimpleKeyAndCertificateHandlerTest {
   public void testSupports() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getRemoteAddr()).thenReturn("227.123.34.21");
-    Mockito.when(request.getRequestURI()).thenReturn(crlPath);
+    Mockito.when(request.getServletPath()).thenReturn(crlPath);
 
     Mockito.when(request.getMethod()).thenReturn("POST");
     Assertions.assertFalse(defaultHandler.supports(request));
@@ -266,7 +266,7 @@ class SimpleKeyAndCertificateHandlerTest {
     Mockito.when(request.getMethod()).thenReturn("GET");
     Assertions.assertTrue(defaultHandler.supports(request));
 
-    Mockito.when(request.getRequestURI()).thenReturn("/other/path.crl");
+    Mockito.when(request.getServletPath()).thenReturn("/other/path.crl");
     Assertions.assertFalse(defaultHandler.supports(request));
   }
 
@@ -274,7 +274,7 @@ class SimpleKeyAndCertificateHandlerTest {
   public void testGetResource() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getRemoteAddr()).thenReturn("227.123.34.21");
-    Mockito.when(request.getRequestURI()).thenReturn(crlPath);
+    Mockito.when(request.getServletPath()).thenReturn(crlPath);
     Mockito.when(request.getMethod()).thenReturn("GET");
 
     final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -293,7 +293,7 @@ class SimpleKeyAndCertificateHandlerTest {
   public void testGetResourceError() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getRemoteAddr()).thenReturn("227.123.34.21");
-    Mockito.when(request.getRequestURI()).thenReturn(crlPath);
+    Mockito.when(request.getServletPath()).thenReturn(crlPath);
     Mockito.when(request.getMethod()).thenReturn("POST");
 
     final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);


### PR DESCRIPTION
Made changes so that the context path does not have to be known in handler implementations. Easier configuration and deployments.