### PR TITLE
IS-58 Fixed dependencies and introduced an application BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This repository comprises of the following modules:
 
 * [app](app) - A sample Signature Service application built using Spring Boot. 
 
+* [bom](bom) - A Maven Bill-of-Materials POM that is useful when building SignService applications.
 
 -----
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3,15 +3,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <groupId>se.swedenconnect.signservice</groupId>
   <artifactId>signservice-demo</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   
-  <parent>
-    <groupId>se.swedenconnect.signservice</groupId>
-    <artifactId>signservice-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>  
-  </parent>  
-
   <name>Sweden Connect :: SignService :: Demo Application</name>
   <description>SignService Demo application</description>
   <url>https://github.com/swedenconnect/signservice</url>
@@ -71,7 +67,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
 
-    <spring.boot.version>2.6.6</spring.boot.version>
+    <spring.boot.version>2.7.1</spring.boot.version>
   </properties>
 
   <repositories>
@@ -101,6 +97,15 @@
   <dependencyManagement>
     
     <dependencies>
+    
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-application-bom</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -108,6 +113,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      
     </dependencies>
 
   </dependencyManagement>
@@ -147,7 +153,6 @@
     <dependency>
       <groupId>se.swedenconnect.signservice</groupId>
       <artifactId>signservice-spring-boot-starter</artifactId>
-      <version>${project.version}</version>    
     </dependency>
 
     <dependency>
@@ -195,6 +200,16 @@
   <build>
 
     <plugins>
+    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>    
 
       <plugin>
         <groupId>org.springframework.boot</groupId>
@@ -230,6 +245,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -244,56 +260,19 @@
           </execution>
         </executions>
       </plugin>
+    
+      <!-- Don't deploy the demo app -->  
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>      
 
     </plugins>
+    
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-
-      <build>
-        <plugins>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>attach-test-sources</id>
-                <goals>
-                  <goal>test-jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-        </plugins>
-      </build>
-
-    </profile>
-  </profiles>
 
 </project>

--- a/bom/README.md
+++ b/bom/README.md
@@ -1,0 +1,40 @@
+![Logo](../docs/images/sweden-connect.png)
+
+
+# signservice/bom
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/se.swedenconnect.signservice/signservice-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/se.swedenconnect.signservice/signservice-bom)
+
+-----
+
+## About
+
+The SignService BOM (Bill of Materials) is a Maven POM that should be imported in an application's
+POM file to get all the latest stable versions of SignService modules. The usage of the BOM also
+prevents dependency convergence errors.
+
+## Usage
+
+In the SignService application POM include the following:
+
+```
+<dependencyManagement>
+  <dependencies>
+    
+    <dependency>
+      <groupId>se.swedenconnect.signservice</groupId>
+      <artifactId>signservice-bom</artifactId>
+      <type>pom</type>
+      <version>${signservice-bom.version}</version>
+      <scope>import</scope>
+    </dependency>
+
+  </dependencies>    
+</dependencyManagement>
+
+```
+
+
+-----
+
+Copyright &copy; 2022, [Myndigheten för digital förvaltning - Swedish Agency for Digital Government (DIGG)](http://www.digg.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,290 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.swedenconnect.signservice</groupId>
+  <artifactId>signservice-application-bom</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Sweden Connect :: SignService :: Application BOM</name>
+  <description>BOM for SignService Applications</description>
+  <url>https://github.com/swedenconnect/signservice</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/swedenconnect/signservice.git</connection>
+    <developerConnection>scm:git:https://github.com/swedenconnect/signservice.git</developerConnection>
+    <url>https://github.com/idsec/signservice/tree/master</url>
+  </scm>
+
+  <organization>
+    <name>Sweden Connect</name>
+    <url>https://www.swedenconnect.se</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <name>Martin Lindström</name>
+      <email>martin@idsec.se</email>
+      <organization>IDsec Solutions AB</organization>
+      <organizationUrl>https://www.idsec.se</organizationUrl>
+    </developer>
+
+    <developer>
+      <name>Stefan Santesson</name>
+      <email>stefan@idsec.se</email>
+      <organization>IDsec Solutions AB</organization>
+      <organizationUrl>https://www.idsec.se</organizationUrl>
+    </developer>
+
+    <developer>
+      <name>Magnus Hoflin</name>
+      <email>magnus.hoflin@digg.se</email>
+      <organization>DIGG</organization>
+      <organizationUrl>https://www.digg.se</organizationUrl>
+    </developer>
+
+    <developer>
+      <name>Henric Norlander</name>
+      <email>extern.henric.norlander@digg.se</email>
+      <organization>DIGG</organization>
+      <organizationUrl>https://www.digg.se</organizationUrl>
+    </developer>
+
+  </developers>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>11</java.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <dependencyManagement>
+
+    <dependencies>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <type>pom</type>
+        <version>5.3.22</version>
+        <scope>import</scope>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.idsec.signservice.commons</groupId>
+        <artifactId>signservice-bom</artifactId>
+        <version>1.2.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      
+      <!-- Jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.13.4</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <!-- <version>${jackson.version}</version> -->
+        <version>[2.14.0-rc1,)</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.13.4</version>
+      </dependency>      
+
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.4</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.cryptacular</groupId>
+        <artifactId>cryptacular</artifactId>
+        <version>1.2.4</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.security</groupId>
+        <artifactId>credentials-support</artifactId>
+        <version>1.2.4</version>
+      </dependency>
+
+      <!-- 
+        We want to force opensaml-addons to be 1.2.4 to avoid the dependency
+        to Velocity that appear in 1.2.3. 
+      -->
+      <dependency>
+        <groupId>se.swedenconnect.opensaml</groupId>
+        <artifactId>opensaml-addons</artifactId>
+        <version>1.2.4</version>       
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.opensaml</groupId>
+        <artifactId>opensaml-security-ext</artifactId>
+        <version>3.1.1</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>4.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-core</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-engine</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-protocol-dssext11</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-authn-base</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-authn-saml</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>    
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-audit-base</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+  
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-audit-actuator</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-signhandler</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+  
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-keycert-base</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>  
+  
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-keycert-simple</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+  
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-keycert-cmc</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>se.swedenconnect.signservice</groupId>
+        <artifactId>signservice-spring-boot-starter</artifactId>
+        <version>1.0.0-SNAPSHOT</version>        
+      </dependency>
+      
+    </dependencies>
+
+  </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+              <!--
+                Allows manual inspection of the staging repo before deploying it to the central repo.
+                Use 'mvn nexus-staging:release -Prelease' to release and 'mvn nexus-staging:drop' to abort.
+                -->
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <module>keycert</module>
     <module>engine</module>
     <module>spring-boot-starter</module>
+    <module>bom</module>
     <module>app</module>
   </modules>
 
@@ -110,20 +111,40 @@
         <scope>import</scope>
       </dependency>
       
+      <!-- Jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.13.4</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <!-- <version>${jackson.version}</version> -->
+        <version>[2.14.0-rc1,)</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.13.4</version>
+      </dependency>      
+      
       <!-- 
         The signservice-bom has a dependency to 1.9.3 which has reported
         vulnerabilities. Until this is fixed, we include it here. 
       -->
       <dependency>
-        <groupId>common-beanutils</groupId>
-        <artifactId>common-beanutils</artifactId>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
         <version>1.9.4</version>
       </dependency>
       
       <dependency>
         <groupId>org.cryptacular</groupId>
         <artifactId>cryptacular</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.4</version>
       </dependency>
       
       <dependency>
@@ -145,7 +166,7 @@
       <dependency>
         <groupId>se.swedenconnect.opensaml</groupId>
         <artifactId>opensaml-security-ext</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
       </dependency>
     
       <dependency>

--- a/signhandler/pom.xml
+++ b/signhandler/pom.xml
@@ -93,7 +93,7 @@
       <artifactId>activation</artifactId>
     </dependency>    
 
-    <!-- JAXB -->
+    <!-- JAXB --> 
     <dependency>
       <groupId>se.swedenconnect.schemas</groupId>
       <artifactId>oasis-dss-jaxb</artifactId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <!-- Versions on dependencies -->
-    <spring.boot.version>2.6.6</spring.boot.version>
+    <spring.boot.version>2.7.1</spring.boot.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Fixed dependencies that were reported by Snyk. We will later release 1.2.3 of the BOM from signservice commons, and by doing so, we don't have to worry that much in our POMs.

I also introduced a BOM that is for applications, i.e., for projects that use of modules to put together a SignService application.

Closes #58 