### PR TITLE
Adding possibility to configure external CRLDP

### DIFF
--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandler.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/SimpleKeyAndCertificateHandler.java
@@ -82,10 +82,10 @@ public class SimpleKeyAndCertificateHandler extends AbstractCaEngineKeyAndCertif
       @Nonnull final AttributeMapper attributeMapper,
       @Nullable final AlgorithmRegistry algorithmRegistry,
       @Nonnull final CAService caService,
-      @Nonnull final String crlPublishPath) {
+      @Nullable final String crlPublishPath) {
     super(keyProvider, algorithmKeyTypes, attributeMapper, algorithmRegistry);
     this.caService = Objects.requireNonNull(caService, "caService must not be null");
-    this.crlPublishPath = Objects.requireNonNull(crlPublishPath, "crlPublishPath must not be null");
+    this.crlPublishPath = crlPublishPath;
     this.caChain = new ArrayList<>();
     try {
       for (final X509CertificateHolder c : this.caService.getCACertificateChain()) {
@@ -180,7 +180,7 @@ public class SimpleKeyAndCertificateHandler extends AbstractCaEngineKeyAndCertif
     if (!"GET".equals(httpRequest.getMethod())) {
       return false;
     }
-    return this.crlPublishPath.equalsIgnoreCase(httpRequest.getServletPath());
+    return this.crlPublishPath != null && this.crlPublishPath.equalsIgnoreCase(httpRequest.getServletPath());
   }
 
 }

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
@@ -17,9 +17,11 @@ package se.swedenconnect.signservice.certificate.simple.config;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.xml.security.signature.XMLSignature;
 
 import lombok.Getter;
@@ -75,6 +77,18 @@ public class SimpleKeyAndCertificateHandlerConfiguration extends AbstractKeyAndC
   private String crlDpPath;
 
   /**
+   * A URL where the CRL is published. This option may be used if the CRL is published under a publicly available
+   * URL to allow validation of the signature certificate.
+   *
+   * <p>
+   *   When this parameter is set crlDpPath is ignored.
+   * </p>
+   */
+  @Getter
+  @Setter
+  private String crlDpUrl;
+
+  /**
    * Even though revocation is not supported we need to support an empty CRL. This property tells where to store this
    * CRL locally.
    */
@@ -100,9 +114,11 @@ public class SimpleKeyAndCertificateHandlerConfiguration extends AbstractKeyAndC
    * @param crlDpPath the CRL distribution path
    */
   public void setCrlDpPath(@Nonnull final String crlDpPath) {
-    this.crlDpPath = Objects.requireNonNull(crlDpPath, "crlDpPath must not be null");
-    if (!this.crlDpPath.startsWith("/")) {
-      throw new IllegalArgumentException("The crlDpPath must begin with a '/'");
+    this.crlDpPath = Optional.ofNullable(crlDpPath)
+      .filter(StringUtils::isNotBlank)
+      .orElse(null);
+    if (this.crlDpPath != null && !this.crlDpPath.startsWith("/")) {
+      throw new IllegalArgumentException("The crlDpPath must be null or begin with a '/'");
     }
   }
 

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfiguration.java
@@ -81,7 +81,7 @@ public class SimpleKeyAndCertificateHandlerConfiguration extends AbstractKeyAndC
    * URL to allow validation of the signature certificate.
    *
    * <p>
-   *   When this parameter is set crlDpPath is ignored.
+   * When this parameter is set {@code crlDpPath} is ignored.
    * </p>
    */
   @Getter

--- a/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactory.java
+++ b/keycert/simple/src/main/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactory.java
@@ -86,15 +86,23 @@ public class SimpleKeyAndCertificateHandlerFactory extends AbstractKeyAndCertifi
     }
 
     final String crlDpPath = Optional.ofNullable(conf.getCrlDpPath())
-        .filter(c -> StringUtils.isNotBlank(c))
-        .orElseThrow(() -> new IllegalArgumentException("CRL distributions point path must be set"));
+      .filter(StringUtils::isNotBlank)
+      .orElse(null);
 
-    final String crlDp = String.format("%s%s", Optional.ofNullable(conf.getBaseUrl())
-        .filter(c -> StringUtils.isNotBlank(c))
-        .orElseThrow(() -> new IllegalArgumentException("Base URL must be set")), crlDpPath);
+    final String crlDp = Optional.ofNullable(conf.getCrlDpUrl())
+      .filter(StringUtils::isNotBlank)
+      .orElseGet(() -> {
+        Optional.ofNullable(crlDpPath)
+          .orElseThrow(() -> new IllegalArgumentException("CRL distributions point path must be set when CRL "
+            + "distribution point URL is not set"));
+        return String.format("%s%s", Optional.ofNullable(conf.getBaseUrl())
+          .filter(StringUtils::isNotBlank)
+          .orElseThrow(() -> new IllegalArgumentException("Base URL must be set to form CRL Distribution point "
+            + "based on path")), crlDpPath);
+      });
 
     final String crlFileLocation = Optional.ofNullable(conf.getCrlFileLocation())
-        .filter(c -> StringUtils.isNotBlank(c))
+        .filter(StringUtils::isNotBlank)
         .orElseThrow(() -> new IllegalArgumentException("CRL file location must be set"));
 
     // Set up a CA service

--- a/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfigurationTest.java
+++ b/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerConfigurationTest.java
@@ -57,12 +57,7 @@ public class SimpleKeyAndCertificateHandlerConfigurationTest {
     assertThatThrownBy(() -> {
       config.setCrlDpPath("path/xyz");
     }).isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The crlDpPath must begin with a '/'");
-
-    assertThatThrownBy(() -> {
-      config.setCrlDpPath(null);
-    }).isInstanceOf(NullPointerException.class)
-        .hasMessage("crlDpPath must not be null");
+        .hasMessage("The crlDpPath must be null or begin with a '/'");
 
   }
 

--- a/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactoryTest.java
+++ b/keycert/simple/src/test/java/se/swedenconnect/signservice/certificate/simple/config/SimpleKeyAndCertificateHandlerFactoryTest.java
@@ -130,6 +130,19 @@ public class SimpleKeyAndCertificateHandlerFactoryTest {
   }
 
   @Test
+  public void testCRLDistributionPointUrl() throws Exception {
+    final SimpleKeyAndCertificateHandlerConfiguration config = this.getFullConfig();
+    final Field crlDp = config.getClass().getSuperclass().getDeclaredField("crlDpPath");
+    crlDp.setAccessible(true);
+    crlDp.set(config, null);
+    final Field crlDpUlr = config.getClass().getSuperclass().getDeclaredField("crlDpUrl");
+    crlDpUlr.setAccessible(true);
+    crlDpUlr.set(config, "https://example.com/crl");
+    final SimpleKeyAndCertificateHandlerFactory factory = new SimpleKeyAndCertificateHandlerFactory();
+    factory.create(config);
+  }
+
+  @Test
   public void testMissingCrlDp() throws Exception {
     final SimpleKeyAndCertificateHandlerConfiguration config = this.getFullConfig();
     final Field crlDp = config.getClass().getSuperclass().getDeclaredField("crlDpPath");
@@ -140,7 +153,7 @@ public class SimpleKeyAndCertificateHandlerFactoryTest {
     assertThatThrownBy(() -> {
       factory.create(config);
     }).isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("CRL distributions point path must be set");
+        .hasMessage("CRL distributions point path must be set when CRL distribution point URL is not set");
   }
 
   @Test
@@ -154,7 +167,7 @@ public class SimpleKeyAndCertificateHandlerFactoryTest {
     assertThatThrownBy(() -> {
       factory.create(config);
     }).isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Base URL must be set");
+        .hasMessage("Base URL must be set to form CRL Distribution point based on path");
   }
 
   @Test


### PR DESCRIPTION
Added capability to configure an external CRLDP.

Tested with

signservice:
  common-beans:
    cert:
      built-in-ca:
        crl-validity: P3653D
        crl-dp-path: #{null}
        crl-dp-url: https://sig.sandbox.swedenconnect.se/crl/local-dev.crl