### PR TITLE
Update FileAuditLoggerTest.java

### DIFF
--- a/audit/base/src/test/java/se/swedenconnect/signservice/audit/file/FileAuditLoggerTest.java
+++ b/audit/base/src/test/java/se/swedenconnect/signservice/audit/file/FileAuditLoggerTest.java
@@ -29,7 +29,7 @@ import se.swedenconnect.signservice.audit.base.events.DefaultAuditEventFactory;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FileAuditLoggerTest {
 
-  private static final String LOG_FILE = "target/fileaudit.log";
+  private static final String LOG_FILE = "target/fileauditloggertest.log";
 
   private MemoryAppender memoryAppenderDebug;
 


### PR DESCRIPTION
Fixing build issue by selecting a unique file name.

As the original file name was used in several tests and not removed properly, one particular test, when building under Windows, stored the log file with an extra ".1" extension, preventing the same tests from finding the log file under its expected name.

With this update, the projects builds without issues.